### PR TITLE
Update 2 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Utilities.Invoker.nuspec
+++ b/MakoIoT.Device.Utilities.Invoker.nuspec
@@ -17,7 +17,7 @@
     <description>Simple transient fault handling (re-try) library for .NET nanoFramework C# projects.</description>
     <tags>nanoFramework C# csharp netmf netnf timezone</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.20" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/Tests/MakoIoT.Device.Utilities.Invoker.Test/MakoIoT.Device.Utilities.Invoker.Test.nfproj
+++ b/Tests/MakoIoT.Device.Utilities.Invoker.Test/MakoIoT.Device.Utilities.Invoker.Test.nfproj
@@ -30,16 +30,16 @@
     <Compile Include="InvokerTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.20.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.20\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=2.1.85.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.85\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=2.1.87.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.87\lib\nanoFramework.TestFramework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.85\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.87\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Tests/MakoIoT.Device.Utilities.Invoker.Test/packages.config
+++ b/Tests/MakoIoT.Device.Utilities.Invoker.Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.20" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="2.1.85" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
+  <package id="nanoFramework.TestFramework" version="2.1.87" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>

--- a/src/MakoIoT.Device.Utilities.Invoker/MakoIoT.Device.Utilities.Invoker.nfproj
+++ b/src/MakoIoT.Device.Utilities.Invoker/MakoIoT.Device.Utilities.Invoker.nfproj
@@ -25,8 +25,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.20.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.20\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/MakoIoT.Device.Utilities.Invoker/packages.config
+++ b/src/MakoIoT.Device.Utilities.Invoker/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.20" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.6.133" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.CoreLibrary from 1.14.20 to 1.15.5</br>Bumps nanoFramework.TestFramework from 2.1.85 to 2.1.87</br>
[version update]

### :warning: This is an automated update. :warning:
